### PR TITLE
Inject GIT_BRANCH and GIT_COMMIT_SHA in env

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,13 +1,13 @@
-import { platform } from 'os'
-import { createWriteStream } from 'fs'
-import fetch from 'node-fetch'
-import { debug, error, setFailed, getInput } from '@actions/core'
-import { exec } from '@actions/exec'
-import { ExecOptions } from '@actions/exec/lib/interfaces'
+import { platform } from 'os';
+import { createWriteStream } from 'fs';
+import fetch from 'node-fetch';
+import { debug, error, setFailed, getInput } from '@actions/core';
+import { exec } from '@actions/exec';
+import { ExecOptions } from '@actions/exec/lib/interfaces';
 
-const DOWNLOAD_URL = `https://codeclimate.com/downloads/test-reporter/test-reporter-latest-${platform()}-amd64`
-const EXECUTABLE = './cc-reporter'
-const DEFAULT_COVERAGE_COMMAND = 'yarn coverage'
+const DOWNLOAD_URL = `https://codeclimate.com/downloads/test-reporter/test-reporter-latest-${platform()}-amd64`;
+const EXECUTABLE = './cc-reporter';
+const DEFAULT_COVERAGE_COMMAND = 'yarn coverage';
 
 export function downloadToFile(
   url: string,
@@ -16,27 +16,27 @@ export function downloadToFile(
 ): Promise<void> {
   return new Promise(async (resolve, reject) => {
     try {
-      const response = await fetch(url, { timeout: 2 * 60 * 1000 }) // Timeout in 2 minutes.
-      const writer = createWriteStream(file, { mode })
-      response.body.pipe(writer)
+      const response = await fetch(url, { timeout: 2 * 60 * 1000 }); // Timeout in 2 minutes.
+      const writer = createWriteStream(file, { mode });
+      response.body.pipe(writer);
       writer.on('close', () => {
-        return resolve()
-      })
+        return resolve();
+      });
     } catch (err) {
-      return reject(err)
+      return reject(err);
     }
-  })
+  });
 }
 
 function prepareEnv() {
-  const env = process.env as { [key: string]: string }
+  const env = process.env as { [key: string]: string };
 
   if (process.env.GITHUB_SHA !== undefined)
-    env.GIT_COMMIT_SHA = process.env.GITHUB_SHA
+    env.GIT_COMMIT_SHA = process.env.GITHUB_SHA;
   if (process.env.GITHUB_REF !== undefined)
-    env.GIT_BRANCH = process.env.GITHUB_REF
+    env.GIT_BRANCH = process.env.GITHUB_REF;
 
-  return env
+  return env;
 }
 
 export function run(
@@ -45,56 +45,56 @@ export function run(
   coverageCommand: string = DEFAULT_COVERAGE_COMMAND
 ): Promise<void> {
   return new Promise(async (resolve, reject) => {
-    let lastExitCode = 1
+    let lastExitCode = 1;
     try {
-      debug(`ℹ️ Downloading CC Reporter from ${downloadUrl} ...`)
-      await downloadToFile(downloadUrl, executable)
-      debug('✅ CC Reporter downloaded...')
+      debug(`ℹ️ Downloading CC Reporter from ${downloadUrl} ...`);
+      await downloadToFile(downloadUrl, executable);
+      debug('✅ CC Reporter downloaded...');
     } catch (err) {
-      error(err.message)
-      setFailed('🚨 CC Reporter download failed!')
-      return reject(err)
+      error(err.message);
+      setFailed('🚨 CC Reporter download failed!');
+      return reject(err);
     }
     const execOpts: ExecOptions = {
       env: prepareEnv()
-    }
+    };
     try {
-      lastExitCode = await exec(executable, ['before-build'], execOpts)
-      debug('✅ CC Reporter before-build checkin completed...')
+      lastExitCode = await exec(executable, ['before-build'], execOpts);
+      debug('✅ CC Reporter before-build checkin completed...');
     } catch (err) {
-      error(err)
-      setFailed('🚨 CC Reporter before-build checkin failed!')
-      return reject(err)
+      error(err);
+      setFailed('🚨 CC Reporter before-build checkin failed!');
+      return reject(err);
     }
     try {
-      lastExitCode = await exec(coverageCommand, undefined, execOpts)
+      lastExitCode = await exec(coverageCommand, undefined, execOpts);
       if (lastExitCode !== 0) {
-        throw new Error(`Coverage run exited with code ${lastExitCode}`)
+        throw new Error(`Coverage run exited with code ${lastExitCode}`);
       }
-      debug('✅ Coverage run completed...')
+      debug('✅ Coverage run completed...');
     } catch (err) {
-      error(err)
-      setFailed('🚨 Coverage run failed!')
-      return reject(err)
+      error(err);
+      setFailed('🚨 Coverage run failed!');
+      return reject(err);
     }
     try {
       await exec(
         executable,
         ['after-build', '--exit-code', lastExitCode.toString()],
         execOpts
-      )
-      debug('✅ CC Reporter after-build checkin completed!')
-      return resolve()
+      );
+      debug('✅ CC Reporter after-build checkin completed!');
+      return resolve();
     } catch (err) {
-      error(err)
-      setFailed('🚨 CC Reporter before-build checkin failed!')
-      return reject(err)
+      error(err);
+      setFailed('🚨 CC Reporter before-build checkin failed!');
+      return reject(err);
     }
-  })
+  });
 }
 
 if (!module.parent) {
-  let coverageCommand = getInput('coverageCommand', { required: false })
-  if (!coverageCommand.length) coverageCommand = DEFAULT_COVERAGE_COMMAND
-  run(DOWNLOAD_URL, EXECUTABLE, coverageCommand)
+  let coverageCommand = getInput('coverageCommand', { required: false });
+  if (!coverageCommand.length) coverageCommand = DEFAULT_COVERAGE_COMMAND;
+  run(DOWNLOAD_URL, EXECUTABLE, coverageCommand);
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,12 +1,13 @@
-import { platform } from 'os';
-import { createWriteStream } from 'fs';
-import fetch from 'node-fetch';
-import { debug, error, setFailed, getInput } from '@actions/core';
-import { exec } from '@actions/exec';
+import { platform } from 'os'
+import { createWriteStream } from 'fs'
+import fetch from 'node-fetch'
+import { debug, error, setFailed, getInput } from '@actions/core'
+import { exec } from '@actions/exec'
+import { ExecOptions } from '@actions/exec/lib/interfaces'
 
-const DOWNLOAD_URL = `https://codeclimate.com/downloads/test-reporter/test-reporter-latest-${platform()}-amd64`;
-const EXECUTABLE = './cc-reporter';
-const DEFAULT_COVERAGE_COMMAND = 'yarn coverage';
+const DOWNLOAD_URL = `https://codeclimate.com/downloads/test-reporter/test-reporter-latest-${platform()}-amd64`
+const EXECUTABLE = './cc-reporter'
+const DEFAULT_COVERAGE_COMMAND = 'yarn coverage'
 
 export function downloadToFile(
   url: string,
@@ -15,16 +16,29 @@ export function downloadToFile(
 ): Promise<void> {
   return new Promise(async (resolve, reject) => {
     try {
-      const response = await fetch(url, { timeout: 2 * 60 * 1000 }); // Timeout in 2 minutes.
-      const writer = createWriteStream(file, { mode });
-      response.body.pipe(writer);
+      const response = await fetch(url, { timeout: 2 * 60 * 1000 }) // Timeout in 2 minutes.
+      const writer = createWriteStream(file, { mode })
+      response.body.pipe(writer)
       writer.on('close', () => {
-        return resolve();
-      });
+        return resolve()
+      })
     } catch (err) {
-      return reject(err);
+      return reject(err)
     }
-  });
+  })
+}
+
+function prepareEnv() {
+  const env: {
+    [key: string]: string
+  } = {}
+  if (process.env.CC_TEST_REPORTER_ID !== undefined)
+    env.CC_TEST_REPORTER_ID = process.env.CC_TEST_REPORTER_ID
+  if (process.env.GITHUB_SHA !== undefined)
+    env.GIT_COMMIT_SHA = process.env.GITHUB_SHA
+  if (process.env.GITHUB_REF !== undefined)
+    env.GIT_BRANCH = process.env.GITHUB_REF
+  return env
 }
 
 export function run(
@@ -33,53 +47,56 @@ export function run(
   coverageCommand: string = DEFAULT_COVERAGE_COMMAND
 ): Promise<void> {
   return new Promise(async (resolve, reject) => {
-    let lastExitCode = 1;
+    let lastExitCode = 1
     try {
-      debug(`ℹ️ Downloading CC Reporter from ${downloadUrl} ...`);
-      await downloadToFile(downloadUrl, executable);
-      debug('✅ CC Reporter downloaded...');
+      debug(`ℹ️ Downloading CC Reporter from ${downloadUrl} ...`)
+      await downloadToFile(downloadUrl, executable)
+      debug('✅ CC Reporter downloaded...')
     } catch (err) {
-      error(err.message);
-      setFailed('🚨 CC Reporter download failed!');
-      return reject(err);
+      error(err.message)
+      setFailed('🚨 CC Reporter download failed!')
+      return reject(err)
+    }
+    const execOpts: ExecOptions = {
+      env: prepareEnv()
     }
     try {
-      lastExitCode = await exec(executable, ['before-build']);
-      debug('✅ CC Reporter before-build checkin completed...');
+      lastExitCode = await exec(executable, ['before-build'], execOpts)
+      debug('✅ CC Reporter before-build checkin completed...')
     } catch (err) {
-      error(err);
-      setFailed('🚨 CC Reporter before-build checkin failed!');
-      return reject(err);
+      error(err)
+      setFailed('🚨 CC Reporter before-build checkin failed!')
+      return reject(err)
     }
     try {
-      lastExitCode = await exec(coverageCommand);
+      lastExitCode = await exec(coverageCommand, undefined, execOpts)
       if (lastExitCode !== 0) {
-        throw new Error(`Coverage run exited with code ${lastExitCode}`);
+        throw new Error(`Coverage run exited with code ${lastExitCode}`)
       }
-      debug('✅ Coverage run completed...');
+      debug('✅ Coverage run completed...')
     } catch (err) {
-      error(err);
-      setFailed('🚨 Coverage run failed!');
-      return reject(err);
+      error(err)
+      setFailed('🚨 Coverage run failed!')
+      return reject(err)
     }
     try {
-      await exec(executable, [
-        'after-build',
-        '--exit-code',
-        lastExitCode.toString()
-      ]);
-      debug('✅ CC Reporter after-build checkin completed!');
-      return resolve();
+      await exec(
+        executable,
+        ['after-build', '--exit-code', lastExitCode.toString()],
+        execOpts
+      )
+      debug('✅ CC Reporter after-build checkin completed!')
+      return resolve()
     } catch (err) {
-      error(err);
-      setFailed('🚨 CC Reporter before-build checkin failed!');
-      return reject(err);
+      error(err)
+      setFailed('🚨 CC Reporter before-build checkin failed!')
+      return reject(err)
     }
-  });
+  })
 }
 
 if (!module.parent) {
-  let coverageCommand = getInput('coverageCommand', { required: false });
-  if (!coverageCommand.length) coverageCommand = DEFAULT_COVERAGE_COMMAND;
-  run(DOWNLOAD_URL, EXECUTABLE, coverageCommand);
+  let coverageCommand = getInput('coverageCommand', { required: false })
+  if (!coverageCommand.length) coverageCommand = DEFAULT_COVERAGE_COMMAND
+  run(DOWNLOAD_URL, EXECUTABLE, coverageCommand)
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -29,15 +29,13 @@ export function downloadToFile(
 }
 
 function prepareEnv() {
-  const env: {
-    [key: string]: string
-  } = {}
-  if (process.env.CC_TEST_REPORTER_ID !== undefined)
-    env.CC_TEST_REPORTER_ID = process.env.CC_TEST_REPORTER_ID
+  const env = process.env as { [key: string]: string }
+
   if (process.env.GITHUB_SHA !== undefined)
     env.GIT_COMMIT_SHA = process.env.GITHUB_SHA
   if (process.env.GITHUB_REF !== undefined)
     env.GIT_BRANCH = process.env.GITHUB_REF
+
   return env
 }
 


### PR DESCRIPTION
As mentioned in [the doc](https://docs.codeclimate.com/docs/test-coverage-troubleshooting-branch-names#section-check-your-cis-environmental-variable-names) code climate needs some env var to set the branch and SHA properly. Unfortunately the [variable names](https://help.github.com/en/articles/virtual-environments-for-github-actions#default-environment-variables) set by GitHub Action are unsupported.

codeclimate/test-reporter#402 will address the problem.

Until that I've made this changes to works with the current test-reporter version.

Up to you to merge or wait for the test-reporter to be compliant with Action.