### PR TITLE
core: Remove 'refs/head/' prefix in Git branch name

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -34,7 +34,7 @@ function prepareEnv() {
   if (process.env.GITHUB_SHA !== undefined)
     env.GIT_COMMIT_SHA = process.env.GITHUB_SHA;
   if (process.env.GITHUB_REF !== undefined)
-    env.GIT_BRANCH = process.env.GITHUB_REF;
+    env.GIT_BRANCH = process.env.GITHUB_REF.replace(/^refs\/head\//, ''); // Remove 'refs/head/' prefix (See https://github.com/paambaati/codeclimate-action/issues/42)
 
   return env;
 }


### PR DESCRIPTION
This should get the coverage to show up in the 'Overview' tab and fix #42.