### PR TITLE
Adds ability to specify coverageLocations

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This action requires that you set the [`CC_TEST_REPORTER_ID`](https://docs.codec
 | `coverageCommand`   | `yarn coverage` | The actual command that should be executed to run your tests and capture coverage. |
 | `debug`             | `false`         | Enable Code Coverage debug output when set to `true`.                              |
 | `coverageLocations` | `[]`            | Locations to find code coverage (Used for builds from multiple locations)          |
+|                     |                 | Format is (location:type, e.g. ./coverage/lcov.info:lcov)                          |
 
 #### Example
 

--- a/README.md
+++ b/README.md
@@ -5,26 +5,28 @@
 A GitHub action that publishes your code coverage to [Code Climate](http://codeclimate.com/).
 
 ## Usage
+
 This action requires that you set the [`CC_TEST_REPORTER_ID`](https://docs.codeclimate.com/docs/configuring-test-coverage) environment variable. You can find it under Repo Settings in your Code Climate project.
 
 ### Inputs
 
-| Input             | Default         | Description                                                                        |
-|-------------------|-----------------|------------------------------------------------------------------------------------|
-| `coverageCommand` | `yarn coverage` | The actual command that should be executed to run your tests and capture coverage. |
-| `debug`           | `false`         | Enable Code Coverage debug output when set to `true`.                              |
+| Input               | Default         | Description                                                                        |
+| ------------------- | --------------- | ---------------------------------------------------------------------------------- |
+| `coverageCommand`   | `yarn coverage` | The actual command that should be executed to run your tests and capture coverage. |
+| `debug`             | `false`         | Enable Code Coverage debug output when set to `true`.                              |
+| `coverageLocations` | `[]`            | Locations to find code coverage (Used for builds from multiple locations)          |
 
 #### Example
 
 ```yaml
 steps:
-- name: Test & publish code coverage
-  uses: paambaati/codeclimate-action@v2.3.0
-  env:
-    CC_TEST_REPORTER_ID: <code_climate_reporter_id>
-  with:
-    coverageCommand: npm run coverage
-    debug: true
+  - name: Test & publish code coverage
+    uses: paambaati/codeclimate-action@v2.3.0
+    env:
+      CC_TEST_REPORTER_ID: <code_climate_reporter_id>
+    with:
+      coverageCommand: npm run coverage
+      debug: true
 ```
 
 Example project — [paambaati/websight](https://github.com/paambaati/websight/blob/663bd4245b3c2dbd768aff9bfc197103ee77973e/.github/workflows/ci.yml#L33-L49)

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,6 +9,7 @@ const DOWNLOAD_URL = `https://codeclimate.com/downloads/test-reporter/test-repor
 const EXECUTABLE = './cc-reporter';
 const DEFAULT_COVERAGE_COMMAND = 'yarn coverage';
 const DEFAULT_CODECLIMATE_DEBUG = 'false';
+const DEFAULT_COVERAGE_LOCATIONS = [];
 
 export function downloadToFile(
   url: string,
@@ -46,7 +47,8 @@ export function run(
   downloadUrl: string = DOWNLOAD_URL,
   executable: string = EXECUTABLE,
   coverageCommand: string = DEFAULT_COVERAGE_COMMAND,
-  codeClimateDebug: string = DEFAULT_CODECLIMATE_DEBUG
+  codeClimateDebug: string = DEFAULT_CODECLIMATE_DEBUG,
+  coverageLocations: Array<String> = DEFAULT_COVERAGE_LOCATIONS
 ): Promise<void> {
   return new Promise(async (resolve, reject) => {
     let lastExitCode = 1;
@@ -81,6 +83,68 @@ export function run(
       setFailed('🚨 Coverage run failed!');
       return reject(err);
     }
+
+    if (!!coverageLocations.length) {
+      //Run format-coverage on each location.
+      for (const i in coverageLocations) {
+        const location = coverageLocations[i];
+        const commands = [
+          'format-coverage',
+          location.toString(),
+          '-o',
+          `/tmp/codeclimate.${i}.json`,
+          '--exit-code',
+          lastExitCode.toString()
+        ];
+        if (codeClimateDebug === 'true') commands.push('--debug');
+
+        try {
+          lastExitCode = await exec(executable, commands, execOpts);
+        } catch (err) {
+          error(err);
+          setFailed('🚨 CC Reporter after-build checkin failed!');
+          return reject(err);
+        }
+      }
+
+      //run sum coverage
+      const sumCommands = [
+        'sum-coverage',
+        'tmp/codeclimate.*.json',
+        '-o',
+        `/tmp/coverage.total.json`,
+        '--exit-code',
+        lastExitCode.toString()
+      ];
+      if (codeClimateDebug === 'true') sumCommands.push('--debug');
+
+      try {
+        lastExitCode = await exec(executable, sumCommands, execOpts);
+      } catch (err) {
+        error(err);
+        setFailed('🚨 CC Reporter after-build checkin failed!');
+        return reject(err);
+      }
+
+      //upload to code climate:
+      const uploadCommands = [
+        'upload-coverage',
+        '-i',
+        `/tmp/coverage.total.json`,
+        '--exit-code',
+        lastExitCode.toString()
+      ];
+      if (codeClimateDebug === 'true') uploadCommands.push('--debug');
+
+      try {
+        lastExitCode = await exec(executable, uploadCommands, execOpts);
+      } catch (err) {
+        error(err);
+        setFailed('🚨 CC Reporter after-build checkin failed!');
+        return reject(err);
+      }
+    }
+
     try {
       const commands = ['after-build', '--exit-code', lastExitCode.toString()];
       if (codeClimateDebug === 'true') commands.push('--debug');
@@ -100,5 +164,15 @@ if (!module.parent) {
   if (!coverageCommand.length) coverageCommand = DEFAULT_COVERAGE_COMMAND;
   let codeClimateDebug = getInput('debug', { required: false });
   if (!coverageCommand.length) codeClimateDebug = DEFAULT_CODECLIMATE_DEBUG;
-  run(DOWNLOAD_URL, EXECUTABLE, coverageCommand, codeClimateDebug);
+  const coverageLocations =
+    getInput('coverageLocations', { required: false }).split(' ') ||
+    DEFAULT_COVERAGE_LOCATIONS;
+
+  run(
+    DOWNLOAD_URL,
+    EXECUTABLE,
+    coverageCommand,
+    codeClimateDebug,
+    coverageLocations
+  );
 }


### PR DESCRIPTION
If you have a mono repo, say a repo that generates multiple different coverage files, this is a way to use code climates supported method to upload these files.