### PR TITLE
Report the correct Git branch name for PRs - fixes #86

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+# [2.5.1] - 2020-02-26
+### Fixed
+- Fix reporting the [wrong branch name for PRs](https://github.com/paambaati/codeclimate-action/issues/86) - via [`#115`](https://github.com/paambaati/codeclimate-action/pull/115).
+
 # [2.5.0] - 2020-02-25
 ### Added
 - Custom `--prefix` support - via [`#111`](https://github.com/paambaati/codeclimate-action/pull/111).

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This action requires that you set the [`CC_TEST_REPORTER_ID`](https://docs.codec
 ```yaml
 steps:
   - name: Test & publish code coverage
-    uses: paambaati/codeclimate-action@v2.5.0
+    uses: paambaati/codeclimate-action@v2.5.1
     env:
       CC_TEST_REPORTER_ID: <code_climate_reporter_id>
     with:
@@ -36,7 +36,7 @@ steps:
 ```yaml
 steps:
   - name: Test & publish code coverage
-    uses: paambaati/codeclimate-action@v2.5.0
+    uses: paambaati/codeclimate-action@v2.5.1
     env:
       # Set CC_TEST_REPORTER_ID as secret of your repo
       CC_TEST_REPORTER_ID: ${{secrets.CC_TEST_REPORTER_ID}}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "codeclimate-action",
-    "version": "2.5.0",
+    "version": "2.5.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "codeclimate-action",
-    "version": "2.5.0",
+    "version": "2.5.1",
     "private": true,
     "description": "Publish code coverage to Code Climate",
     "main": "lib/main.js",

--- a/src/main.ts
+++ b/src/main.ts
@@ -40,6 +40,11 @@ function prepareEnv() {
 
   if (env.GIT_BRANCH)
     env.GIT_BRANCH = env.GIT_BRANCH.replace(/^refs\/heads\//, ''); // Remove 'refs/heads/' prefix (See https://github.com/paambaati/codeclimate-action/issues/42)
+
+  if (process.env.GITHUB_EVENT_NAME === 'pull_request') {
+    env.GIT_BRANCH = process.env.GITHUB_HEAD_REF || env.GIT_BRANCH; // Report correct branch for PRs (See https://github.com/paambaati/codeclimate-action/issues/86)
+  }
+
   return env;
 }
 


### PR DESCRIPTION
This PR introduces a fix for #86 - this action should now report the correct branch name in coverage reports for pull requests.