### PR TITLE
Only add `--prefix` when `prefix` option was specified.

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -54,7 +54,7 @@ export function run(
   coverageCommand: string = DEFAULT_COVERAGE_COMMAND,
   codeClimateDebug: string = DEFAULT_CODECLIMATE_DEBUG,
   coverageLocations: Array<String> = DEFAULT_COVERAGE_LOCATIONS,
-  coveragePrefix: string | undefined = undefined
+  coveragePrefix: string
 ): Promise<void> {
   return new Promise(async (resolve, reject) => {
     let lastExitCode = 1;
@@ -108,7 +108,7 @@ export function run(
           `codeclimate.${i}.json`
         ];
         if (codeClimateDebug === 'true') commands.push('--debug');
-        if (!coveragePrefix && typeof coveragePrefix === 'string') {
+        if (coveragePrefix) {
           commands.push('--prefix', coveragePrefix);
         }
 


### PR DESCRIPTION
`@actions/core`s `getInput` **always** returns a string ([see implementation](https://github.com/actions/toolkit/blob/%40actions/core%401.1.0/packages/core/src/core.ts#L72-L80)).  Prior to these changes, the logic:

```js
if (!coveragePrefix && typeof coveragePrefix === 'string') {
```

Would only pass the `--prefix` argument when the action was either configured with a `prefix: ""` or no prefix at all.

This changes to ensure that we only specify `--prefix` when a `prefix` option was specified. In the default case (no `prefix` option) the passed `coveragePrefix` would be `""` which is falsey and would therefore avoid adding `--prefix`.