### PR TITLE
Fail Action if `before-build` or `after-build` Return a Non-Zero Exit Code

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
     "requires": true,
     "dependencies": {
         "@actions/core": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.2.3.tgz",
-            "integrity": "sha512-Wp4xnyokakM45Uuj4WLUxdsa8fJjKVl1fDTsPbTEcTcuu0Nb26IPQbOtjmnfaCPGcaoPOOqId8H9NapZ8gii4w=="
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.2.4.tgz",
+            "integrity": "sha512-YJCEq8BE3CdN8+7HPZ/4DxJjk/OkZV2FFIf+DlZTC/4iBlzYCD5yjRR6eiOS5llO11zbRltIRuKAjMKaWTE6cg=="
         },
         "@actions/exec": {
             "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "author": "GP <me@httgp.com>",
     "license": "MIT",
     "dependencies": {
-        "@actions/core": "^1.2.3",
+        "@actions/core": "^1.2.4",
         "@actions/exec": "^1.0.3",
         "@actions/github": "^2.1.1",
         "node-fetch": "^2.6.0"

--- a/src/main.ts
+++ b/src/main.ts
@@ -80,6 +80,11 @@ export function run(
     };
     try {
       lastExitCode = await exec(executable, ['before-build'], execOpts);
+      if (lastExitCode !== 0) {
+        throw new Error(
+          `Coverage after-build exited with code ${lastExitCode}`
+        );
+      }
       debug('✅ CC Reporter before-build checkin completed...');
     } catch (err) {
       error(err);
@@ -198,7 +203,12 @@ export function run(
     try {
       const commands = ['after-build', '--exit-code', lastExitCode.toString()];
       if (codeClimateDebug === 'true') commands.push('--debug');
-      await exec(executable, commands, execOpts);
+      lastExitCode = await exec(executable, commands, execOpts);
+      if (lastExitCode !== 0) {
+        throw new Error(
+          `Coverage after-build exited with code ${lastExitCode}`
+        );
+      }
       debug('✅ CC Reporter after-build checkin completed!');
       return resolve();
     } catch (err) {


### PR DESCRIPTION
In a similar fashion to the other commands, after running the `before-build` or `after-build` steps we should fail the action if they return with a non-zero exit code.

---

In our setup we use `simplecov`, of which versions after 0.17, produce a coverage report whose format is incompatible with `cc-test-reporter`. This produces failures in the `after-build` command, for example:

```
2020-08-18T10:02:02.6528716Z [command]/home/runner/work/cms/cms/cc-reporter after-build --exit-code 0
2020-08-18T10:02:02.7785615Z Error: json: cannot unmarshal object into Go struct field input.coverage of type []formatters.NullInt
2020-08-18T10:02:02.7792113Z Usage:
2020-08-18T10:02:02.7792927Z   cc-test-reporter after-build [flags]
2020-08-18T10:02:02.7793147Z 
2020-08-18T10:02:02.7793360Z Flags:
2020-08-18T10:02:02.7793764Z   -s, --batch-size int               batch size for source files (default 500)
2020-08-18T10:02:02.7794312Z   -e, --coverage-endpoint string     endpoint to upload coverage information to (default "https://api.codeclimate.com/v1/test_reports")
2020-08-18T10:02:02.7794860Z   -t, --coverage-input-type string   type of input source to use [clover, cobertura, coverage.py, excoveralls, gcov, gocov, jacoco, lcov, simplecov, xccov]
2020-08-18T10:02:02.7795281Z       --exit-code int                exit code of the test run
2020-08-18T10:02:02.7796525Z   -r, --id string                    reporter identifier (default "***")
2020-08-18T10:02:02.7797282Z       --insecure                     send coverage insecurely (without HTTPS)
2020-08-18T10:02:02.7797996Z   -p, --prefix string                the root directory where the coverage analysis was performed (default "/home/runner/work/cms/cms")
2020-08-18T10:02:02.7798276Z 
2020-08-18T10:02:02.7798482Z Global Flags:
2020-08-18T10:02:02.7798946Z   -d, --debug   run in debug mode
```

In our specific case, as we use dependabot to update dependencies, we'd like this to fail the action to prevent the dependency from being updated. More generally I think it makes sense for this to fail the action in order to alert the user to fix the issue, although this could potentially be a breaking change for some user's setups.

I suspect this would fix #181 