### PR TITLE
Add workingDirectory input

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This action requires that you set the [`CC_TEST_REPORTER_ID`](https://docs.codec
 | Input               | Default         | Description                                                                        |
 | ------------------- | --------------- | ---------------------------------------------------------------------------------- |
 | `coverageCommand`   | `yarn coverage` | The actual command that should be executed to run your tests and capture coverage. |
+| `workingDirectory`  |                 | Specify a custom working directory where the coverage command should be executed.  |
 | `debug`             | `false`         | Enable Code Coverage debug output when set to `true`.                              |
 | `coverageLocations` |                 | Locations to find code coverage as a multiline string.<br>Each line should be of the form `<location>:<type>`. See examples below.
 | `prefix`            | `undefined`     | See [`--prefix`](https://docs.codeclimate.com/docs/configuring-test-coverage)      |

--- a/action.yml
+++ b/action.yml
@@ -9,6 +9,10 @@ inputs:
     required: false
     description: 'Coverage command to execute'
     default: 'yarn coverage'
+  workingDirectory:
+    required: false
+    description: 'Custom working directory for executing the coverage command'
+    default: ''
   debug:
     required: false
     description: 'Enable debugging logs for the Code Climate test reporter'

--- a/src/main.ts
+++ b/src/main.ts
@@ -68,7 +68,7 @@ export function run(
     if (workingDirectory) {
       debug(`Changing working directory to: ${workingDirectory}`);
       try {
-        await chdir(workingDirectory);
+        chdir(workingDirectory);
         lastExitCode = 0;
         debug('✅ Changing working directory completed...');
       } catch (err) {


### PR DESCRIPTION
When checking out multiple repos within a single GitHub workflow, the use of `path` becomes necessary to keep things organized, but also creates the need to move across directories to accomplish certain tasks. In the case of running unit tests for a specific project folder, this usually leaves the resulting files in the directories where the test command was executed.

Code Climate's `cc-test-report` binary does not support pre-pending the path to the "location" of the coverage files, and also searches for a `.git/` directory in the current working directory. These two conditions make it necessary to run the binary within the proper location.

GitHub actions’ `uses` step does not allow specifying a `working-directory` in which to run the action being "used". At the same time, the `uses` step doesn't seem to execute a shell (thus the `run` item does not apply to it), hence the `cd` shell builtin is never available. Pre-pending `cd <path> &&` to the `coverageCommand` input results in an error due to this.

This patch adds a `workingDirectory` input to this GH action, which allows changing to a custom working directory via Node.js’ `process.chdir()` function. It also fixes a few places where `error()` was being passed non-string values, thus giving runtime errors.