### PR TITLE
Make `coverageCommand` optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This action requires that you set the [`CC_TEST_REPORTER_ID`](https://docs.codec
 
 | Input               | Default         | Description                                                                        |
 | ------------------- | --------------- | ---------------------------------------------------------------------------------- |
-| `coverageCommand`   | `yarn coverage` | The actual command that should be executed to run your tests and capture coverage. |
+| `coverageCommand`   |                 | The actual command that should be executed to run your tests and capture coverage. |
 | `workingDirectory`  |                 | Specify a custom working directory where the coverage command should be executed.  |
 | `debug`             | `false`         | Enable Code Coverage debug output when set to `true`.                              |
 | `coverageLocations` |                 | Locations to find code coverage as a multiline string.<br>Each line should be of the form `<location>:<type>`. See examples below.
@@ -29,6 +29,18 @@ steps:
     with:
       coverageCommand: npm run coverage
       debug: true
+```
+
+#### Example with only upload
+
+When you've already generated the coverage report in a previous step and wish to just upload the coverage data to Code Climate, you can leave out the `coverageCommand` option.
+
+```yaml
+steps:
+  - name: Test & publish code coverage
+    uses: paambaati/codeclimate-action@v2.7.0
+    env:
+      CC_TEST_REPORTER_ID: <code_climate_reporter_id>
 ```
 
 #### Example with multiple coverage locations

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,7 +11,7 @@ import { getOptionalString } from './utils';
 
 const DOWNLOAD_URL = `https://codeclimate.com/downloads/test-reporter/test-reporter-latest-${platform()}-amd64`;
 const EXECUTABLE = './cc-reporter';
-const DEFAULT_COVERAGE_COMMAND = 'yarn coverage';
+const DEFAULT_COVERAGE_COMMAND = '';
 const DEFAULT_WORKING_DIRECTORY = '';
 const DEFAULT_CODECLIMATE_DEBUG = 'false';
 const DEFAULT_COVERAGE_LOCATIONS = '';
@@ -106,16 +106,23 @@ export function run(
       setFailed('🚨 CC Reporter before-build checkin failed!');
       return reject(err);
     }
-    try {
-      lastExitCode = await exec(coverageCommand, undefined, execOpts);
-      if (lastExitCode !== 0) {
-        throw new Error(`Coverage run exited with code ${lastExitCode}`);
+
+    if (coverageCommand) {
+      try {
+        lastExitCode = await exec(coverageCommand, undefined, execOpts);
+        if (lastExitCode !== 0) {
+          throw new Error(`Coverage run exited with code ${lastExitCode}`);
+        }
+        debug('✅ Coverage run completed...');
+      } catch (err) {
+        error(err.message);
+        setFailed('🚨 Coverage run failed!');
+        return reject(err);
       }
-      debug('✅ Coverage run completed...');
-    } catch (err) {
-      error(err.message);
-      setFailed('🚨 Coverage run failed!');
-      return reject(err);
+    } else {
+      info(
+        `ℹ️ 'coverageCommand' not set, so skipping building coverage report!`
+      );
     }
 
     const coverageLocations = coverageLocationsParam


### PR DESCRIPTION
Closes https://github.com/paambaati/codeclimate-action/issues/182

This PR makes `coverageCommand` optional.