### PR TITLE
234 - Glob support for coverage locations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -368,6 +368,51 @@
                 "@types/node": ">= 8"
             }
         },
+        "@sinonjs/commons": {
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.1.tgz",
+            "integrity": "sha512-892K+kWUUi3cl+LlqEWIDrhvLgdL79tECi8JZUyq6IviKy/DNhuzCRlbHUjxK89f4ypPMMaFnFuR9Ie6DoIMsw==",
+            "dev": true,
+            "requires": {
+                "type-detect": "4.0.8"
+            }
+        },
+        "@sinonjs/fake-timers": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz",
+            "integrity": "sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==",
+            "dev": true,
+            "requires": {
+                "@sinonjs/commons": "^1.7.0"
+            }
+        },
+        "@sinonjs/formatio": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-5.0.1.tgz",
+            "integrity": "sha512-KaiQ5pBf1MpS09MuA0kp6KBQt2JUOQycqVG1NZXvzeaXe5LGFqAKueIS0bw4w0P9r7KuBSVdUk5QjXsUdu2CxQ==",
+            "dev": true,
+            "requires": {
+                "@sinonjs/commons": "^1",
+                "@sinonjs/samsam": "^5.0.2"
+            }
+        },
+        "@sinonjs/samsam": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-5.1.0.tgz",
+            "integrity": "sha512-42nyaQOVunX5Pm6GRJobmzbS7iLI+fhERITnETXzzwDZh+TtDr/Au3yAvXVjFmZ4wEUaE4Y3NFZfKv0bV0cbtg==",
+            "dev": true,
+            "requires": {
+                "@sinonjs/commons": "^1.6.0",
+                "lodash.get": "^4.4.2",
+                "type-detect": "^4.0.8"
+            }
+        },
+        "@sinonjs/text-encoding": {
+            "version": "0.7.1",
+            "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+            "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
+            "dev": true
+        },
         "@types/color-name": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
@@ -387,6 +432,21 @@
                 "@types/node": "*",
                 "form-data": "^3.0.0"
             }
+        },
+        "@types/sinon": {
+            "version": "9.0.7",
+            "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-9.0.7.tgz",
+            "integrity": "sha512-uyFiy2gp4P/FK9pmU3WIbT5ZzH54hCswwRkQFhxX7xl8jzhW3g+xOkVqk5YP4cIO//Few8UDAX0MtzFpqBEqwA==",
+            "dev": true,
+            "requires": {
+                "@types/sinonjs__fake-timers": "*"
+            }
+        },
+        "@types/sinonjs__fake-timers": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-6.0.2.tgz",
+            "integrity": "sha512-dIPoZ3g5gcx9zZEszaxLSVTvMReD3xxyyDnQUjA6IYDG9Ba2AV0otMPs+77sG9ojB4Qr2N2Vk5RnKeuA0X/0bg==",
+            "dev": true
         },
         "@types/tape": {
             "version": "4.13.0",
@@ -1156,6 +1216,12 @@
                 "minimist": "^1.2.5"
             }
         },
+        "just-extend": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.1.1.tgz",
+            "integrity": "sha512-aWgeGFW67BP3e5181Ep1Fv2v8z//iBJfrvyTnq8wG86vEESwmonn1zPBJ0VfmT9CJq2FIT0VsETtrNFm2a+SHA==",
+            "dev": true
+        },
         "locate-path": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
@@ -1173,6 +1239,12 @@
             "version": "4.4.0",
             "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
             "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI="
+        },
+        "lodash.get": {
+            "version": "4.4.2",
+            "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+            "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+            "dev": true
         },
         "lodash.set": {
             "version": "4.3.2",
@@ -1226,6 +1298,19 @@
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
             "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "nise": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/nise/-/nise-4.0.4.tgz",
+            "integrity": "sha512-bTTRUNlemx6deJa+ZyoCUTRvH3liK5+N6VQZ4NIw90AgDXY6iPnsqplNFf6STcj+ePk0H/xqxnP75Lr0J0Fq3A==",
+            "dev": true,
+            "requires": {
+                "@sinonjs/commons": "^1.7.0",
+                "@sinonjs/fake-timers": "^6.0.0",
+                "@sinonjs/text-encoding": "^0.7.1",
+                "just-extend": "^4.0.2",
+                "path-to-regexp": "^1.7.0"
+            }
         },
         "nock": {
             "version": "13.0.4",
@@ -1410,6 +1495,23 @@
             "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
             "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
         },
+        "path-to-regexp": {
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+            "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+            "dev": true,
+            "requires": {
+                "isarray": "0.0.1"
+            },
+            "dependencies": {
+                "isarray": {
+                    "version": "0.0.1",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+                    "dev": true
+                }
+            }
+        },
         "pkg-dir": {
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
@@ -1560,6 +1662,38 @@
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
             "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
+        },
+        "sinon": {
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/sinon/-/sinon-9.1.0.tgz",
+            "integrity": "sha512-9zQShgaeylYH6qtsnNXlTvv0FGTTckuDfHBi+qhgj5PvW2r2WslHZpgc3uy3e/ZAoPkqaOASPi+juU6EdYRYxA==",
+            "dev": true,
+            "requires": {
+                "@sinonjs/commons": "^1.7.2",
+                "@sinonjs/fake-timers": "^6.0.1",
+                "@sinonjs/formatio": "^5.0.1",
+                "@sinonjs/samsam": "^5.1.0",
+                "diff": "^4.0.2",
+                "nise": "^4.0.4",
+                "supports-color": "^7.1.0"
+            },
+            "dependencies": {
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                }
+            }
         },
         "source-map": {
             "version": "0.6.1",
@@ -1746,6 +1880,12 @@
             "version": "0.0.6",
             "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
             "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="
+        },
+        "type-detect": {
+            "version": "4.0.8",
+            "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+            "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+            "dev": true
         },
         "type-fest": {
             "version": "0.8.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,15 @@
                 "@octokit/plugin-rest-endpoint-methods": "^4.0.0"
             }
         },
+        "@actions/glob": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/@actions/glob/-/glob-0.1.0.tgz",
+            "integrity": "sha512-lx8SzyQ2FE9+UUvjqY1f28QbTJv+w8qP7kHHbfQRhphrlcx0Mdmm1tZdGJzfxv1jxREa/sLW4Oy8CbGQKCJySA==",
+            "requires": {
+                "@actions/core": "^1.2.0",
+                "minimatch": "^3.0.4"
+            }
+        },
         "@actions/http-client": {
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-1.0.8.tgz",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
         "@actions/core": "^1.2.6",
         "@actions/exec": "^1.0.4",
         "@actions/github": "^4.0.0",
+        "@actions/glob": "^0.1.0",
         "hook-std": "^2.0.0",
         "node-fetch": "^2.6.1",
         "nyc": "^15.1.0"

--- a/package.json
+++ b/package.json
@@ -35,9 +35,11 @@
     "devDependencies": {
         "@types/node": "^14.11.2",
         "@types/node-fetch": "^2.5.7",
+        "@types/sinon": "^9.0.7",
         "@types/tape": "^4.13.0",
         "nock": "^13.0.4",
         "prettier": "^2.1.2",
+        "sinon": "^9.1.0",
         "tape": "^5.0.1",
         "to-readable-stream": "^2.1.0",
         "ts-node": "^9.0.0",

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -2,9 +2,13 @@ import test from 'tape';
 import nock from 'nock';
 import toReadableStream from 'to-readable-stream';
 import { default as hookStd } from 'hook-std';
+import * as glob from '@actions/glob';
+import sinon from 'sinon';
 import { tmpdir } from 'os';
+import { resolve as resolvePath } from 'path';
 import {
   stat as statCallback,
+  writeFileSync,
   unlinkSync,
   realpath as realpathCallback,
 } from 'fs';
@@ -27,6 +31,8 @@ const realpath = promisify(realpathCallback);
 
 const DEFAULT_WORKDIR = process.cwd();
 let DEFAULT_ECHO = '/bin/echo';
+
+const sandbox = sinon.createSandbox();
 
 test('🛠 setup', (t) => {
   nock.disableNetConnect();
@@ -154,6 +160,95 @@ after-build --exit-code 0
     'should execute all steps (except running the coverage command).'
   );
   unlinkSync(filePath);
+  nock.cleanAll();
+  t.end();
+});
+
+test('🧪 run() should convert patterns to locations.', async (t) => {
+  t.plan(3);
+  const globSpy = sandbox
+    .stub()
+    .resolves([
+      resolvePath(__dirname, './file-a.lcov'),
+      resolvePath(__dirname, './file-b.lcov'),
+    ]);
+  sandbox.stub(glob, 'create').resolves({
+    glob: globSpy,
+    getSearchPaths: sandbox.spy(),
+    globGenerator: sandbox.spy(),
+  });
+  const filePath = './test.sh';
+  nock('http://localhost.test')
+    .get('/dummy-cc-reporter')
+    .reply(200, () => {
+      return toReadableStream(`#!/bin/bash
+echo "$*"
+`); // Dummy shell script that just echoes back all arguments.
+    });
+
+  const filePattern = './*.lcov:lcov';
+  const fileA = 'file-a.lcov';
+  const fileB = 'file-b.lcov';
+
+  writeFileSync(fileA, 'file a content');
+  writeFileSync(fileB, 'file b content');
+
+  let capturedOutput = '';
+  const stdHook = hookStd((text: string) => {
+    capturedOutput += text;
+  });
+
+  try {
+    await run(
+      'http://localhost.test/dummy-cc-reporter',
+      filePath,
+      '',
+      '',
+      'false',
+      filePattern
+    );
+    stdHook.unhook();
+  } catch (err) {
+    stdHook.unhook();
+    t.fail(err);
+  } finally {
+    nock.cleanAll();
+  }
+
+  t.deepEquals(
+    ((glob.create as unknown) as sinon.SinonSpy).firstCall.firstArg,
+    './*.lcov',
+    'should create a globber with given pattern'
+  );
+  t.true(
+    globSpy.calledOnceWithExactly(),
+    'should get the paths of the files from the newly created globber instance'
+  );
+  t.equal(
+    capturedOutput,
+    // prettier-ignore
+    `::debug::ℹ️ Downloading CC Reporter from http://localhost.test/dummy-cc-reporter ...
+::debug::✅ CC Reporter downloaded...
+[command]${resolvePath(__dirname, '../test.sh')} before-build
+before-build
+::debug::✅ CC Reporter before-build checkin completed...
+ℹ️ 'coverageCommand' not set, so skipping building coverage report!
+::debug::Parsing 2 coverage location(s) — ${resolvePath(__dirname, 'file-a.lcov')}:lcov,${resolvePath(__dirname, 'file-b.lcov')}:lcov (object)
+[command]${resolvePath(__dirname, '../test.sh')} format-coverage ${resolvePath(__dirname, 'file-a.lcov')} -t lcov -o codeclimate.0.json
+format-coverage ${resolvePath(__dirname, 'file-a.lcov')} -t lcov -o codeclimate.0.json
+[command]${resolvePath(__dirname, '../test.sh')} format-coverage ${resolvePath(__dirname, 'file-b.lcov')} -t lcov -o codeclimate.1.json
+format-coverage ${resolvePath(__dirname, 'file-b.lcov')} -t lcov -o codeclimate.1.json
+[command]${resolvePath(__dirname, '../test.sh')} sum-coverage codeclimate.0.json codeclimate.1.json -p 2 -o coverage.total.json
+sum-coverage codeclimate.0.json codeclimate.1.json -p 2 -o coverage.total.json
+[command]${resolvePath(__dirname, '../test.sh')} upload-coverage -i coverage.total.json
+upload-coverage -i coverage.total.json
+::debug::✅ CC Reporter upload coverage completed!
+`,
+    'should execute all steps (except running the coverage command).'
+  );
+  unlinkSync(filePath);
+  unlinkSync(fileA);
+  unlinkSync(fileB);
   nock.cleanAll();
   t.end();
 });


### PR DESCRIPTION
Now you can pass globs as coverage locations, `@actions/glob` is used to convert them to absolute paths.

Fixes #234 