### PR TITLE
Add prefix command to after-build call

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -256,6 +256,10 @@ export function run(
     try {
       const commands = ['after-build', '--exit-code', lastExitCode.toString()];
       if (codeClimateDebug === 'true') commands.push('--debug');
+      if (coveragePrefix) {
+        commands.push('--prefix', coveragePrefix);
+      }
+
       lastExitCode = await exec(executable, commands, execOpts);
       if (lastExitCode !== 0) {
         throw new Error(


### PR DESCRIPTION
This addresses #265. 

#### Summary

The `after-build` job is documented to "Locate, parse, and re-format supported coverage sources. Upload pre-formatted coverage payloads to Code Climate servers.", therefore, we should support the coverage prefix for this call.

#### Changes

I added a check for the coveragePrefix and if it exists it will apply the prefix flag.