### PR TITLE
Adds support for add-prefix

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,10 @@ inputs:
     required: false
     description: 'See https://docs.codeclimate.com/docs/configuring-test-coverage'
     default: ''
+  addPrefix:
+    required: false
+    description: 'See https://docs.codeclimate.com/docs/configuring-test-coverage'
+    default: ''
 runs:
   using: 'node12'
   main: 'lib/main.js'

--- a/src/main.ts
+++ b/src/main.ts
@@ -95,7 +95,8 @@ export function run(
   workingDirectory: string = DEFAULT_WORKING_DIRECTORY,
   codeClimateDebug: string = DEFAULT_CODECLIMATE_DEBUG,
   coverageLocationsParam: string = DEFAULT_COVERAGE_LOCATIONS,
-  coveragePrefix?: string
+  coveragePrefix?: string,
+  addCoveragePrefix?: string
 ): Promise<void> {
   return new Promise(async (resolve, reject) => {
     let lastExitCode = 1;
@@ -195,6 +196,9 @@ export function run(
         if (coveragePrefix) {
           commands.push('--prefix', coveragePrefix);
         }
+        if (addCoveragePrefix) {
+          commands.push('--add-prefix', addCoveragePrefix);
+        }
 
         parts.push(`codeclimate.${i}.json`);
 
@@ -259,6 +263,9 @@ export function run(
       if (coveragePrefix) {
         commands.push('--prefix', coveragePrefix);
       }
+      if (addCoveragePrefix) {
+        commands.push('--add-prefix', addCoveragePrefix);
+      }
 
       lastExitCode = await exec(executable, commands, execOpts);
       if (lastExitCode !== 0) {
@@ -294,6 +301,7 @@ if (require.main === module) {
     DEFAULT_COVERAGE_LOCATIONS
   );
   const coveragePrefix = getOptionalString('prefix');
+  const addCoveragePrefix = getOptionalString('addPrefix');
 
   run(
     DOWNLOAD_URL,
@@ -302,6 +310,7 @@ if (require.main === module) {
     workingDirectory,
     codeClimateDebug,
     coverageLocations,
-    coveragePrefix
+    coveragePrefix,
+    addCoveragePrefix
   );
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -263,9 +263,6 @@ export function run(
       if (coveragePrefix) {
         commands.push('--prefix', coveragePrefix);
       }
-      if (addCoveragePrefix) {
-        commands.push('--add-prefix', addCoveragePrefix);
-      }
 
       lastExitCode = await exec(executable, commands, execOpts);
       if (lastExitCode !== 0) {


### PR DESCRIPTION
I couldn't find any reference to this in previous issues so I decided to go ahead and add it myself.

This PR adds an optional parameter to allow passing in the `add-prefix` option, which is supported by `format-coverage` and required in order to add a prefix to your coverage paths (for situations where your tests are generated from a subfolder rather than from the root of the project). Note this is different from the `prefix` option you already have, which removes the indicated prefix.

More info: repository A contains two subfolders, `folder1` and `folder2`. CodeClimate is tracking the whole repository, but tests are executed from `folder1/tests`. In this case, CodeClimate expects paths in the format `folder1/${path_to_file}`, but the coverage report will have `${path_to_file}`. For this reason, CodeClimate will show the total coverage correctly, but the individual files won't have coverage annotations. 
Now, the test-reporter executable provided by CodeClimate has a flag for it's `format-coverage` action called `--add-prefix`, which essentially indicates the formatter to add a prefix to each of the paths in the coverage report. Having the option to pass this flag as a parameter when using this action is essential, and that is what this PR is trying to achieve.

Let me know your thoughts!