### PR TITLE
Attempted fix at a yaml parsing issue

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -27,7 +27,7 @@ inputs:
     default: ''
   verifyDownload:
     required: false
-    description: 'Verify the downloaded reporter''s checksum and GPG signature'
+    description: 'Verify the downloaded reporter their checksum and GPG signature'
     default: 'true'
 runs:
   using: 'node12'


### PR DESCRIPTION
I'm not sure if this will fix anything at all, honestly it feels very doubtful. This is standard YAML formatting and surely GitHub should support it?

Either way, I ran into:

```
Error: paambaati/codeclimate-action/v3/action.yml: (Line: 30, Col: 51, Idx: 902) - 
  (Line: 30, Col: 80, Idx: 931): While parsing a block mapping, did not find expected key.
Error: System.ArgumentException: Unexpected type '' encountered while reading 'action manifest root'. The type 'MappingToken' was expected.
```

My workflow yaml:

```yaml
name: Coverage

on: ["push", "pull_request"]

jobs:
  coverage:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v3
      - name: Set up Go
        uses: actions/setup-go@v3
        with:
          go-version: 1.18
      - name: Generate coverage
        run: go test -race -coverprofile=coverage.out -covermode=atomic ./...
      - name: Upload coverage
        uses: paambaati/codeclimate-action@v3
        continue-on-error: true
        env:
          CC_TEST_REPORTER_ID: ${{ secrets.COVERAGE_SECRET }}
        with:
          debug: true
```
