### PR TITLE
Update to node 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -30,5 +30,5 @@ inputs:
     description: 'Verify the downloaded reporter''s checksum and GPG signature'
     default: 'true'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'lib/main.js'


### PR DESCRIPTION
See: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/ should solve #621, I don't know if other steps are required