### PR TITLE
feat: Support monorepos with an prefixFromCoverageDirectory option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@ lib/
 node_modules/
 coverage/
 .nyc_output/
+.idea/
 
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -108,8 +108,8 @@ export function run(
   codeClimateDebug: string = DEFAULT_CODECLIMATE_DEBUG,
   coverageLocationsParam: string = DEFAULT_COVERAGE_LOCATIONS,
   coveragePrefix?: string,
-  prefixCoverageDirectories: string = DEFAULT_PREFIX_COVERAGE_DIRECTORIES,
-  verifyDownload: string = DEFAULT_VERIFY_DOWNLOAD
+  verifyDownload: string = DEFAULT_VERIFY_DOWNLOAD,
+  prefixCoverageDirectories: string = DEFAULT_PREFIX_COVERAGE_DIRECTORIES
 ): Promise<void> {
   return new Promise(async (resolve, reject) => {
     if (platform() === 'win32') {
@@ -386,8 +386,8 @@ if (require.main === module) {
       codeClimateDebug,
       coverageLocations,
       coveragePrefix,
-      prefixCoverageDirectories,
-      verifyDownload
+      verifyDownload,
+      prefixCoverageDirectories
     );
   } catch (err) {
     throw err;


### PR DESCRIPTION
Great workflow, but I'd like to add support for monorepos, or situations where multiple prefixes need to be supported alongside multiple coverage files.

This change adds a 'prefixFromCoverageDirectory' option. When true, it will tell cc's formatter to prefix for the immediate parent directory of each found coverage file.

Happy to contribute a different approach, as this might be too bespoke for our use case (a lerna/npm workspaces JS monorepo)