### PR TITLE
fix(core): support ARM 64-bit environments

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -15,7 +15,9 @@ import type { ExecOptions } from '@actions/exec/lib/interfaces';
 
 // REFER: https://docs.codeclimate.com/docs/configuring-test-coverage#locations-of-pre-built-binaries
 /** Canonical download URL for the official CodeClimate reporter. */
-export const DOWNLOAD_URL = `https://codeclimate.com/downloads/test-reporter/test-reporter-latest-${platform()}-${arch() === 'arm64' ? 'arm64' : 'amd64'}`;
+export const DOWNLOAD_URL = `https://codeclimate.com/downloads/test-reporter/test-reporter-latest-${platform()}-${
+  arch() === 'arm64' ? 'arm64' : 'amd64'
+}`;
 /** Local file name of the CodeClimate reporter. */
 export const EXECUTABLE = './cc-reporter';
 export const CODECLIMATE_GPG_PUBLIC_KEY_ID =

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { platform } from 'os';
+import { platform, arch } from 'os';
 import { chdir } from 'process';
 import { unlinkSync } from 'fs';
 import { debug, error, setFailed, warning, info } from '@actions/core';
@@ -13,8 +13,9 @@ import {
 } from './utils';
 import type { ExecOptions } from '@actions/exec/lib/interfaces';
 
+// REFER: https://docs.codeclimate.com/docs/configuring-test-coverage#locations-of-pre-built-binaries
 /** Canonical download URL for the official CodeClimate reporter. */
-export const DOWNLOAD_URL = `https://codeclimate.com/downloads/test-reporter/test-reporter-latest-${platform()}-amd64`;
+export const DOWNLOAD_URL = `https://codeclimate.com/downloads/test-reporter/test-reporter-latest-${platform()}-${arch() === 'arm64' ? 'arm64' : 'amd64'}`;
 /** Local file name of the CodeClimate reporter. */
 export const EXECUTABLE = './cc-reporter';
 export const CODECLIMATE_GPG_PUBLIC_KEY_ID =


### PR DESCRIPTION
Fixes https://github.com/paambaati/codeclimate-action/issues/663.

NOTE: `os.arch()` only returns the architecture the Node.js binary was compiled for, not the host platform's architecture. This change is still okay for most real-world scenarios out there.