### PR TITLE
chore(docs): document simplecov parser issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ This action requires that you set the [`CC_TEST_REPORTER_ID`](https://docs.codec
 | `prefix`            | `undefined`     | See [`--prefix`](https://docs.codeclimate.com/docs/configuring-test-coverage)      |
 | `verifyDownload`    | `true`          | Verifies the downloaded Code Climate reporter binary's checksum and GPG signature. See [Verifying binaries](https://github.com/codeclimate/test-reporter#verifying-binaries)      |
 
-> For SimpleCov, we recommend using `gem "simplecov_json_formatter"` because the `coverage/.resultset.json` returns a `json` error.
+> **Note**
+> If you are a Ruby developer using [SimpleCov](https://github.com/simplecov-ruby/simplecov), other users have recommended installing an additional gem – `gem "simplecov_json_formatter"` – this gem fixes `json` error from the default `coverage/.resultset.json` output from SimpleCov.
 
 #### Example
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ This action requires that you set the [`CC_TEST_REPORTER_ID`](https://docs.codec
 | `prefix`            | `undefined`     | See [`--prefix`](https://docs.codeclimate.com/docs/configuring-test-coverage)      |
 | `verifyDownload`    | `true`          | Verifies the downloaded Code Climate reporter binary's checksum and GPG signature. See [Verifying binaries](https://github.com/codeclimate/test-reporter#verifying-binaries)      |
 
+> For SimpleCov, we recommend using `gem "simplecov_json_formatter"` because the `coverage/.resultset.json` returns a `json` error.
+
 #### Example
 
 ```yaml


### PR DESCRIPTION
Hey, thanks for creating the extension!

I'm installing it [here](https://github.com/JuanVqz/doctors/pull/392) for a Rails app using the SimpleCov gem.

I noticed that SimpleCov by default generates a `.resultset.json` file but it [failed when sending](https://github.com/JuanVqz/doctors/actions/runs/5559116055/jobs/10154902095#step:8:42) the data to the SimpleCov endpoint to fix that I had to install another [gem called simplecov_json_formatter](https://github.com/codeclimate-community/simplecov_json_formatter) that parsed it [correctly](https://github.com/JuanVqz/doctors/actions/runs/5559139645/jobs/10154947629?pr=392).

So, to save everybody times I guess is good to add a hint in the readme with the findings I did.

If you think there is something else we can do please let me know I'm happy to contribute, again thanks!

Also, you may link [this pr](https://github.com/JuanVqz/doctors/pull/392) as a Rails example if you want.