### PR TITLE
Run `src/main.ts` instead of `lib/main.js`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -31,4 +31,4 @@ inputs:
     default: 'true'
 runs:
   using: 'node20'
-  main: 'lib/main.js'
+  main: 'src/main.ts'


### PR DESCRIPTION
Fixed issue when running main in github actions

`Error: File not found: '/home/runner/work/_actions/paambaati/codeclimate-action/main/lib/main.js'`